### PR TITLE
Fix pylint issues

### DIFF
--- a/lambdas/stay_event_adapter/handler.py
+++ b/lambdas/stay_event_adapter/handler.py
@@ -3,10 +3,12 @@
 import json
 import os
 import hashlib
-from query import STAY_COMPLETED_QUERY
 from dataclasses import asdict
 from datetime import datetime, timedelta
 from decimal import Decimal
+
+from query import STAY_COMPLETED_QUERY
+from botocore.exceptions import BotoCoreError, ClientError
 
 # Standard AWS clients
 import boto3
@@ -23,6 +25,8 @@ DEDUP_TABLE_NAME = os.environ["DEDUP_TABLE_NAME"]
 REDSHIFT_SECRET_ARN = os.environ["REDSHIFT_SECRET_ARN"]
 
 def get_redshift_connection():
+    """Return a connection to Redshift using credentials from Secrets Manager."""
+
     response = secrets_client.get_secret_value(SecretId=REDSHIFT_SECRET_ARN)
     secret = json.loads(response["SecretString"])
 
@@ -31,10 +35,12 @@ def get_redshift_connection():
         database=secret["dbname"],
         user=secret["username"],
         password=secret["password"],
-        port=int(secret["port"])
+        port=int(secret["port"]),
     )
 
-def handler(event, _):
+def handler(_event, _):
+    """Entry point for the stay event adapter Lambda."""
+
     try:
         conn = get_redshift_connection()
         cursor = conn.cursor()
@@ -59,17 +65,22 @@ def handler(event, _):
                     mark_as_processed(row_hash)
                 else:
                     print("Duplicate detected, skipping.")
-            except redshift_connector.Error as e:
-                print("Row processing error:", e)
+            except redshift_connector.Error as error:
+                print("Row processing error:", error)
                 continue
 
         return {"statusCode": 200, "body": f"Processed {len(rows)} rows"}
 
-    except Exception as e:
-        print("Top-level error:", e)
+    except redshift_connector.Error as error:
+        print("Top-level Redshift error:", error)
+        raise
+    except (BotoCoreError, ClientError) as error:
+        print("AWS client error:", error)
         raise
 
 def transform_to_event(row: BookingRow):
+    """Convert a BookingRow into the outbound event structure."""
+
     event = {
         "eventType": "StayCompleted"
     }
@@ -82,45 +93,55 @@ def transform_to_event(row: BookingRow):
 
 
 def publish_event(payload):
+    """Publish the transformed event payload to SNS."""
+
     try:
         sns_client.publish(
             TopicArn=SNS_TOPIC_ARN,
-            Message=json.dumps(payload, default=json_safe)
+            Message=json.dumps(payload, default=json_safe),
         )
         print("Published:", payload)
-    except Exception as e:
-        print("Failed to publish:", e)
+    except (BotoCoreError, ClientError) as error:
+        print("Failed to publish:", error)
 
 def hash_row(row: BookingRow):
+    """Generate a SHA-256 hash for a booking row."""
+
     row_string = json.dumps(asdict(row), sort_keys=True, default=json_safe)
     return hashlib.sha256(row_string.encode("utf-8")).hexdigest()
 
 
 def is_duplicate(event_hash):
+    """Return True if the hash already exists in DynamoDB."""
+
     try:
         response = dynamodb_client.get_item(
             TableName=DEDUP_TABLE_NAME,
-            Key={"EventHash": {"S": event_hash}}
+            Key={"EventHash": {"S": event_hash}},
         )
         return "Item" in response
-    except Exception as e:
-        print("DynamoDB read error:", e)
+    except ClientError as error:
+        print("DynamoDB read error:", error)
         return False
 
 def mark_as_processed(event_hash):
+    """Record the processed hash in DynamoDB with a TTL."""
+
     try:
         ttl = int((datetime.utcnow() + timedelta(days=3)).timestamp())
         dynamodb_client.put_item(
             TableName=DEDUP_TABLE_NAME,
             Item={
                 "EventHash": {"S": event_hash},
-                "TTL": {"N": str(ttl)}
-            }
+                "TTL": {"N": str(ttl)},
+            },
         )
-    except Exception as e:
-        print("DynamoDB write error:", e)
+    except ClientError as error:
+        print("DynamoDB write error:", error)
 
 def json_safe(obj):
+    """Convert Decimal objects to float for JSON serialization."""
+
     if isinstance(obj, Decimal):
         return float(obj)
     return str(obj)

--- a/lambdas/stay_event_adapter/models/booking_row.py
+++ b/lambdas/stay_event_adapter/models/booking_row.py
@@ -1,9 +1,12 @@
+"""Data model representing a booking row fetched from Redshift."""
+
 from dataclasses import dataclass, asdict, fields
 from typing import Optional
 from decimal import Decimal
 
 @dataclass
-class BookingRow:
+class BookingRow:  # pylint: disable=too-many-instance-attributes
+    """Container for all fields returned by the stay-completed query."""
     resv_nbr: Optional[str] = None
     resv_detail_id: Optional[str] = None
     booking_dt_key: Optional[str] = None
@@ -107,9 +110,13 @@ class BookingRow:
         return BookingRow(**filtered)
 
     def to_dict(self) -> dict:
+        """Return a dictionary representation of the dataclass."""
+
         return asdict(self)
 
 def safe_asdict(obj: BookingRow) -> dict:
+    """Serialize a BookingRow to a dict converting Decimals to floats."""
+
     return {
         k: float(v) if isinstance(v, Decimal) else v
         for k, v in asdict(obj).items()

--- a/lambdas/stay_event_adapter/query.py
+++ b/lambdas/stay_event_adapter/query.py
@@ -1,4 +1,4 @@
-# SQL query to fetch completed stays from Redshift
+"""SQL query string used by the adapter Lambda."""
 
 STAY_COMPLETED_QUERY = """
 SELECT

--- a/lambdas/test_subscriber/handler.py
+++ b/lambdas/test_subscriber/handler.py
@@ -1,10 +1,11 @@
+"""Simple SNS subscriber used for testing."""
+
 import json
 
-# AWS X-Ray instrumentation
-# from aws_xray_sdk.core import patch_all
-# patch_all()
 
-def handler(event, context):
+def handler(event, _context):
+    """Log the SNS message payload."""
+
     print("SNS event received:")
     print(json.dumps(event, indent=2))
 

--- a/stay_event_adapter_poc/stay_event_adapter_poc_stack.py
+++ b/stay_event_adapter_poc/stay_event_adapter_poc_stack.py
@@ -23,13 +23,13 @@ from aws_cdk import (
 from aws_cdk.aws_lambda_event_sources import SqsEventSource
 from constructs import Construct
 
-class StayEventAdapterPocStack(Stack):
+class StayEventAdapterPocStack(Stack):  # pylint: disable=too-few-public-methods
     """
     Defines the CDK stack for the Stay Event Adapter POC.
     Includes SNS topics, SQS queues, Lambda functions, CloudWatch alarms,
     and Redshift secret configuration.
     """
-    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:  # pylint: disable=too-many-locals
         super().__init__(scope,
                         construct_id,
                         **kwargs)

--- a/tests/unit/test_hash_row.py
+++ b/tests/unit/test_hash_row.py
@@ -1,3 +1,5 @@
+"""Unit tests for the hash_row helper."""
+
 import os
 import sys
 import json
@@ -15,11 +17,13 @@ os.environ.setdefault("SNS_TOPIC_ARN", "arn:aws:sns:us-east-1:123456789012:test"
 os.environ.setdefault("DEDUP_TABLE_NAME", "table")
 os.environ.setdefault("REDSHIFT_SECRET_ARN", "secret")
 
-import handler
-from models.booking_row import BookingRow
+from models.booking_row import BookingRow  # pylint: disable=wrong-import-position
+import handler  # pylint: disable=wrong-import-position
 
 
 def test_hash_row_returns_expected_digest():
+    """hash_row should produce a deterministic digest."""
+
     row = BookingRow(resv_nbr="1")
     digest = handler.hash_row(row)
 

--- a/tests/unit/test_stay_event_adapter_poc_stack.py
+++ b/tests/unit/test_stay_event_adapter_poc_stack.py
@@ -1,18 +1,23 @@
-import aws_cdk as core
-import aws_cdk.assertions as assertions
+"""Integration tests for the CDK stack."""
+
 import os
+import aws_cdk as core
+from aws_cdk import assertions
 
 from stay_event_adapter_poc.stay_event_adapter_poc_stack import StayEventAdapterPocStack
 
 # example tests. To run these tests, uncomment this file along with the example
 # resource in stay_event_adapter_poc/stay_event_adapter_poc_stack.py
 def test_stack_synthesizes():
+    """Verify that the stack can be synthesized."""
+
     app = core.App()
     layer_zip = os.path.join(
         os.path.dirname(__file__), "..", "..", "lambda-layers", "data-services-layer.zip"
     )
     # Create an empty layer artifact so the stack can synthesize
-    open(layer_zip, "a").close()
+    with open(layer_zip, "a", encoding="utf-8"):
+        pass
     stack = StayEventAdapterPocStack(
         app,
         "stay-event-adapter-poc",


### PR DESCRIPTION
## Summary
- clean up imports in stay_event adapter handler
- add docstrings and adjust error handling
- document booking_row model and helper functions
- add simple test subscriber module
- address CDK stack pylint warnings
- tidy unit tests

## Testing
- `pytest -q`
- `pylint $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687b1b7f1c5c832785e0ff69e68598ff